### PR TITLE
Ubuntu 20.04 Building instructions fix, re. librust-libdbus-sys-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Unless you're a cool hackerman, the easiest way to get `libudev`, `libevdev`, an
 
 ```bash
 # e.g: on ubuntu
-sudo apt install libevdev-dev libhidapi-dev libudev-dev
+sudo apt install libevdev-dev libhidapi-dev libudev-dev librust-libdbus-sys-dev
 ```
 
 Once those are installed, `surface-dial-daemon` can be built using the standard `cargo build` flow.


### PR DESCRIPTION
Ubuntu 20.04 required this extra dependency not to die with error on build. Adding.